### PR TITLE
Ensure resource can be queried *during* provision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- A resource can now be queried *during* the provisioning flow instead of after
+  it's completed.
+
 ## [0.6.3] - 2017-04-19
 
 ### Fixed

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -25,6 +25,10 @@ var ErrCallbackNotFound = errors.New("Callback Not Found")
 // has already been resolved
 var ErrCallbackAlreadyResolved = errors.New("Callback Already Resolved")
 
+// ErrResourceNotFound represents an error which occurrs if the resource does
+// not exist
+var ErrResourceNotFound = errors.New("Resource Not Found")
+
 // RequestCapturer represents functionality for capturing and storing requests
 // for a specific route
 type RequestCapturer struct {
@@ -99,6 +103,18 @@ func (c *FakeConnector) GetCapturer(route string) (*RequestCapturer, error) {
 // AddResource stores a resource inside the connector
 func (c *FakeConnector) AddResource(r *Resource) {
 	c.resources = append(c.resources, r)
+}
+
+// RemoveResource deletes a resource stored inside the connector
+func (c *FakeConnector) RemoveResource(ID manifold.ID) error {
+	for i, r := range c.resources {
+		if r.ID == ID {
+			c.resources = append(c.resources[:i], c.resources[i+1:]...)
+			return nil
+		}
+	}
+
+	return ErrResourceNotFound
 }
 
 // GetResource returns a Resource for the ID or nil

--- a/connector/connector_test.go
+++ b/connector/connector_test.go
@@ -1,0 +1,60 @@
+package connector
+
+import (
+	"testing"
+	"time"
+
+	gm "github.com/onsi/gomega"
+
+	"github.com/manifoldco/go-manifold"
+	"github.com/manifoldco/go-manifold/idtype"
+)
+
+var (
+	port         uint
+	clientID     = "21jtaatqj8y5t0kctb2ejr6jev5w8"
+	clientSecret = "3yTKSiJ6f5V5Bq-kWF0hmdrEUep3m3HKPTcPX7CdBZw"
+	product      = "tester"
+)
+
+func makeResource(t *testing.T, plan, region string) *Resource {
+	ID, err := manifold.NewID(idtype.Resource)
+	if err != nil {
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+		return nil
+	}
+
+	return &Resource{
+		ID:        ID,
+		Product:   product,
+		Plan:      plan,
+		Region:    region,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+}
+
+func TestConnector(t *testing.T) {
+	gm.RegisterTestingT(t)
+
+	c, err := New(port, clientID, clientSecret, product)
+	if err != nil {
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+	}
+
+	t.Run("a resource is available if added and not if removed", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		r := makeResource(t, "high", "aws::us-east-1")
+		c.AddResource(r)
+
+		found := c.GetResource(r.ID)
+		gm.Expect(found).ToNot(gm.BeNil(), "resource should have been found")
+
+		err := c.RemoveResource(r.ID)
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+
+		found = c.GetResource(r.ID)
+		gm.Expect(found).To(gm.BeNil())
+	})
+}


### PR DESCRIPTION
Previously, a resource could not be queried *during* the provision flow.

However, this does not match the behaviour of Manifold's production
stack!