### PR TITLE
Remove Double Slash from SSO URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+- If a trailing slash is provided for the base url, Grafton will no longer
+  generate urls with duplicate `/` between path segments.
+
 ## [0.6.4] - 2017-04-20
 
 ### Fixed

--- a/client.go
+++ b/client.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	nurl "net/url"
-	"path/filepath"
+	"path"
 
 	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
@@ -91,7 +91,7 @@ func deriveCallbackURL(connectorURL *nurl.URL, cbID manifold.ID) (string, error)
 		return "", err
 	}
 
-	u.Path = u.Path + "/callbacks/" + cbID.String()
+	u.Path = path.Join(u.Path, "callbacks/"+cbID.String())
 	return u.String(), nil
 }
 
@@ -215,7 +215,7 @@ func (c *Client) DeprovisionResource(ctx context.Context, cbID, resourceID manif
 func (c *Client) CreateSsoURL(code string, resourceID manifold.ID) *nurl.URL {
 	url := *c.url
 
-	url.Path = filepath.Join(url.Path, "/sso/")
+	url.Path = path.Join(url.Path, "sso/")
 	q := nurl.Values{}
 	q.Set("code", code)
 	q.Set("resource_id", resourceID.String())

--- a/generated/provider/client/credential/delete_credentials_id_parameters.go
+++ b/generated/provider/client/credential/delete_credentials_id_parameters.go
@@ -218,7 +218,9 @@ func (o *DeleteCredentialsIDParams) SetID(id string) {
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteCredentialsIDParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
-	r.SetTimeout(o.timeout)
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
 	var res []error
 
 	// header param Date

--- a/generated/provider/client/credential/put_credentials_id_parameters.go
+++ b/generated/provider/client/credential/put_credentials_id_parameters.go
@@ -238,7 +238,9 @@ func (o *PutCredentialsIDParams) SetID(id string) {
 // WriteToRequest writes these params to a swagger request
 func (o *PutCredentialsIDParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
-	r.SetTimeout(o.timeout)
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
 	var res []error
 
 	// header param Date

--- a/generated/provider/client/resource/delete_resources_id_parameters.go
+++ b/generated/provider/client/resource/delete_resources_id_parameters.go
@@ -218,7 +218,9 @@ func (o *DeleteResourcesIDParams) SetID(id string) {
 // WriteToRequest writes these params to a swagger request
 func (o *DeleteResourcesIDParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
-	r.SetTimeout(o.timeout)
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
 	var res []error
 
 	// header param Date

--- a/generated/provider/client/resource/patch_resources_id_parameters.go
+++ b/generated/provider/client/resource/patch_resources_id_parameters.go
@@ -236,7 +236,9 @@ func (o *PatchResourcesIDParams) SetID(id string) {
 // WriteToRequest writes these params to a swagger request
 func (o *PatchResourcesIDParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
-	r.SetTimeout(o.timeout)
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
 	var res []error
 
 	// header param Date

--- a/generated/provider/client/resource/put_resources_id_parameters.go
+++ b/generated/provider/client/resource/put_resources_id_parameters.go
@@ -236,7 +236,9 @@ func (o *PutResourcesIDParams) SetID(id string) {
 // WriteToRequest writes these params to a swagger request
 func (o *PutResourcesIDParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
-	r.SetTimeout(o.timeout)
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
 	var res []error
 
 	// header param Date

--- a/generated/provider/client/single_sign_on/get_sso_parameters.go
+++ b/generated/provider/client/single_sign_on/get_sso_parameters.go
@@ -138,7 +138,9 @@ func (o *GetSsoParams) SetResourceID(resourceID string) {
 // WriteToRequest writes these params to a swagger request
 func (o *GetSsoParams) WriteToRequest(r runtime.ClientRequest, reg strfmt.Registry) error {
 
-	r.SetTimeout(o.timeout)
+	if err := r.SetTimeout(o.timeout); err != nil {
+		return err
+	}
 	var res []error
 
 	// query param code


### PR DESCRIPTION
Depending on the url provided, it was possible for an sso or callback
url to have two `//` between path segments instead of one breaking some
web servers.

Also fixes the build by upgrading to the latest greatest swagger :)