### PR TITLE
Always append v1 to url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - If a trailing slash is provided for the base url, Grafton will no longer
   generate urls with duplicate `/` between path segments.
+- Update README to include working example using `grafton test`
 - `/v1` will always be prepended to the base url given to Grafton
 
 ## [0.6.4] - 2017-04-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - If a trailing slash is provided for the base url, Grafton will no longer
   generate urls with duplicate `/` between path segments.
+- `/v1` will always be prepended to the base url given to Grafton
 
 ## [0.6.4] - 2017-04-20
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,12 @@ deprovision those before resizing the resource. Finally, Grafton will
 deprovision the resource.
 
 ```
-$ grafton test --product=generators --plan=low --new-plan=high \
-  --region=aws::us-east-1 http://localhost:3000
+grafton test --product=bonnets --plan=small --region=aws::us-east-1 \
+    --client-id=21jtaatqj8y5t0kctb2ejr6jev5w8 \
+    --client-secret=3yTKSiJ6f5V5Bq-kWF0hmdrEUep3m3HKPTcPX7CdBZw \
+    --connector-port=3001 \
+    --new-plan=large \
+    http://localhost:4567
 ```
 
 ## On editing the OpenAPI spec

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	nurl "net/url"
 	"os"
+	"path"
 	"strings"
 	"text/tabwriter"
 
@@ -128,7 +129,7 @@ func testCmd(ctx *cli.Context) error {
 
 	purl, err := nurl.Parse(url)
 	if err != nil {
-		return cli.NewExitError("unable to parse url", -1)
+		return cli.NewExitError("unable to parse url: "+url, -1)
 	}
 
 	// Always append the '/v1' to the path

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -131,9 +131,8 @@ func testCmd(ctx *cli.Context) error {
 		return cli.NewExitError("unable to parse url", -1)
 	}
 
-	if purl.Path == "" {
-		purl.Path = "/v1"
-	}
+	// Always append the '/v1' to the path
+	purl.Path = path.Join(purl.Path, "/v1")
 
 	k, err := getKeypair()
 	if err != nil {


### PR DESCRIPTION
I've fixed two small bugs:

- Ensure we always append `/v1` to the provided base url
- Update the readme to include a valid example of how to run the `grafton test` command