### PR TITLE
Append `/v1` if not already provided in base url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+- A backwards incompatible change was accidently introduced in `v0.6.5`, `/v1`
+  would always be appended to the url, instead, `/v1` will only be appended if
+  the provided url does not end with `/v1`.
+
 ## [0.6.5] - 2017-04-27
 
 ### Fixed

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -133,7 +133,9 @@ func testCmd(ctx *cli.Context) error {
 	}
 
 	// Always append the '/v1' to the path
-	purl.Path = path.Join(purl.Path, "/v1")
+	if !strings.HasSuffix(purl.Path, "/v1") {
+		purl.Path = path.Join(purl.Path, "/v1")
+	}
 
 	k, err := getKeypair()
 	if err != nil {


### PR DESCRIPTION
A backwards incomptabile change was introduced in a previous commit
which would *always* append `/v1` to the url. Instead, this commit makes
it only append `/v1` if the given url does not have a trailing `/v1`
segment.