### PR TITLE
Convert client errors into Grafton Errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,18 +1,74 @@
 package grafton
 
 import (
+	"errors"
 	"net/http"
 
+	swagerrs "github.com/go-openapi/errors"
 	"github.com/go-openapi/runtime"
 
 	"github.com/manifoldco/go-manifold"
-	"github.com/manifoldco/go-manifold/errors"
+	merrors "github.com/manifoldco/go-manifold/errors"
 )
+
+// ErrMissingMsg occurs when a provider's response is missing the Message field
+var ErrMissingMsg = errors.New("`message` field was missing from the response")
+
+// NewErrWithMsg creates a new Error from a string pointer, if the pointer is
+// nil then an ErrMissingMsg is returned instead.
+func NewErrWithMsg(t merrors.Type, m *string) error {
+	if m == nil {
+		return ErrMissingMsg
+	}
+
+	return NewError(t, *m)
+}
+
+// IsFatal returns true or false depending on whether or not the given error is
+// considered to be fatal
+func IsFatal(err error) bool {
+	switch e := err.(type) {
+	case *Error:
+		if e.Type == merrors.InternalServerError {
+			return false
+		}
+
+		return true
+	case swagerrs.Error:
+		// If status code is 5xx, then something went terribly wrong on their
+		// side, so we want to try again
+		//
+		// 6xx and above are status codes used by go-openapi to represent
+		// different schema related errors
+		//
+		// We don't consider 2xx codes as non-fatal because someplace upstream
+		// we didn't understand what was sent to us.
+		code := int(e.Code())
+		if code >= 500 && code < 600 {
+			return false
+		}
+
+		return true
+	case *runtime.APIError:
+		// If its a runtime error (which occurs inside the client) has a status
+		// code between 500 and 600, then it's not fatal, otherwise, it is :)
+		//
+		// We don't consider 2xx codes as non-fatal because someplace upstream
+		// we didn't understand what was sent to us.
+		if e.Code >= 500 && e.Code < 600 {
+			return false
+		}
+
+		return true
+	default:
+		return false
+	}
+}
 
 // Error is the error type we'll use for providers to return.
 type Error struct {
-	Type    errors.Type `json:"error"`
-	Message string      `json:"message"`
+	Type    merrors.Type `json:"error"`
+	Message string       `json:"message"`
 }
 
 // Error returns the message of the error.
@@ -44,16 +100,16 @@ func ToError(err error) manifold.HTTPError {
 	case *Error:
 		return e
 	case manifold.HTTPError:
-		if et, ok := errors.TypeForStatusCode(e.StatusCode()); ok {
+		if et, ok := merrors.TypeForStatusCode(e.StatusCode()); ok {
 			return NewError(et, e.Error())
 		}
 	}
 
-	return NewError(errors.InternalServerError, "Internal Server Error")
+	return NewError(merrors.InternalServerError, "Internal Server Error")
 }
 
 // NewError creates a new Error with a type and message.
-func NewError(t errors.Type, m string) *Error {
+func NewError(t merrors.Type, m string) *Error {
 	return &Error{
 		Type:    t,
 		Message: m,


### PR DESCRIPTION
Where possible, we now convert errors returned from the generated client
into Grafton errors.

At the same time, I've gone through and added exhaustive tests for the
various different http errors we can encounter.