### PR TITLE
Validate Credential Names during Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,13 @@ go:
 branches:
   only:
   - master
-install: make bootstrap
+before_install:
+- mkdir -p $HOME/gopath/bin
+install:
+- export PATH=$PATH:$TRAVIS_BUILD_DIR/vendor/bin:$GOPATH/bin
+- echo $PATH
+- pwd
+- make bootstrap
 notifications:
   slack:
     secure: QogbolWEjUXgs4g33wCZIpK6LYqmTnujgsTIkJSr0IbkdF3LZXMa8frxldksv8p7njIjnFanNd5D47TlJ6caqT6K52QP6Puf0rVKkYpIjpuk1nObphHjC/mvZEBjsjLQzR9vNYqJwkUrbc4dLTQKV2NrS8hOSS5kDHmsNJfsv4WfGVohZp/pCWDkLhOHZflrHZkNlvqp6gfVY6P5GJw8Q4U0sA0z/9Y0xNoCaWYJpHu3Y/DBG7DuCZCrJt6zF0a7Bpzy5Fd01kfF8F6GwZGpm3FQ4X6HuheJVfQON5hJ+M9/uDPHvl4TM5gNE7kvEbLyUDlmhMj04rwgfBpm1Svg7h1cMr1MQUPURJClxkIDJGY+8eNVYKGibhaSUYUYTo3h/nE8dMmLKdAwdJZRrq6WmEtbWodQq++jeAGqkWk0+RK88GSEKN2xcl2ygOlOCkIo4SP+7CE9bAqzWjx+1Ssw5NHhgjGd4JKuXkOf099czgLwbScxr1jTW/LCFS060KoNoYdDy01kHy3+ysTlAmeTjKSEXaMuyBjg3MVVrBoQEK+4j2EnRWrYHRWW8R1MOVkAMAKRk/UgXNzFl9GhMrveBxiqKnYv+2ZqhQuxYR46ktW/xdm0c+dJlorFlgmRV1CsSNAYxvNPP8ZYVGquv0fqH2Aa/PEVfgxoX1SnZQ86bKs=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [x.y.z] - YYYY-MM-DD (Unreleased)
+
+### Improvements
+
+- The `grafton test` command now validates the credential names it receives.
+- The main `grafton` package now exports a function `ValidCredentialName` for
+  testing whether or not a given credential name is valid.
+
 ## [0.8.0] - 2017-05-14
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - The `grafton test` command now validates the credential names it receives.
 - The main `grafton` package now exports a function `ValidCredentialName` for
   testing whether or not a given credential name is valid.
+- Dependencies for bootstrapping the build are now vendored using glide.
 
 ## [0.8.0] - 2017-05-14
 

--- a/acceptance/credentials.go
+++ b/acceptance/credentials.go
@@ -46,6 +46,11 @@ var creds = Feature("credentials", "Create a credential set", func(ctx context.C
 			"One or more credentials should be returned during provision of a Credential set",
 		)
 
+		for name := range creds {
+			gm.Expect(grafton.ValidCredentialName(name)).To(
+				gm.BeTrue(), "Credential name must be of the form "+grafton.NameRegexpString)
+		}
+
 		credentialID = cID
 	})
 

--- a/credentials.go
+++ b/credentials.go
@@ -1,0 +1,19 @@
+package grafton
+
+import (
+	"regexp"
+)
+
+// NameRegexpString is the string form of a regular expression for determining
+// if a credential name is valid or not.
+//
+// Specified in Shell and Utilities volume of IEEE 1003.1-2001.
+const NameRegexpString = "^[A-Z][A-Z0-9_]{0,127}$"
+
+var nameRegexp = regexp.MustCompile(NameRegexpString)
+
+// ValidCredentialName returns true or false depending on whether or not the
+// given name is a valid credential name.
+func ValidCredentialName(name string) bool {
+	return nameRegexp.MatchString(name)
+}

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -1,0 +1,28 @@
+package grafton
+
+import (
+	"testing"
+
+	gm "github.com/onsi/gomega"
+)
+
+func TestValidCredentialName(t *testing.T) {
+	tcs := []struct {
+		in  string
+		out bool
+	}{
+		{"090asdfaf", false},
+		{"AS_DSDA", true},
+		{"_DDF", false},
+		{"DFS_SDF", true},
+		{"D08_DF_", true},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.in, func(t *testing.T) {
+			gm.RegisterTestingT(t)
+
+			gm.Expect(ValidCredentialName(tc.in)).To(gm.Equal(tc.out))
+		})
+	}
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,16 @@
-hash: b8d2dc33404956af1e6bdd720a266a9b752c7918c86324058d4a9885e561dd83
-updated: 2017-04-12T21:21:53.790348012-03:00
+hash: 0691276178654320a4652dedc01fc6563a10c20636ff11316aaab8c2a0939a0e
+updated: 2017-05-29T16:42:23.985162557-03:00
 imports:
+- name: github.com/alecthomas/gometalinter
+  version: bae2f1293d092fd8167939d5108d1b025eaef9de
 - name: github.com/asaskevich/govalidator
   version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
 - name: github.com/chzyer/readline
   version: 41eea22f717c616615e1e59aa06cf831f9901f35
+- name: github.com/client9/misspell
+  version: d06ddd376b273047dca6e16eeeb2a2a8f9791978
+  subpackages:
+  - cmd/misspell
 - name: github.com/dchest/blake2b
   version: 06006a921c7d13e3fdf63c401cb0e4529a26e6e4
 - name: github.com/dgrijalva/jwt-go
@@ -33,8 +39,18 @@ imports:
   version: d5f8ebc3b1c55a4cf6489eeae7354f338cfe299e
 - name: github.com/go-openapi/validate
   version: 035dcd74f1f61e83debe1c22950dc53556e7e4b2
+- name: github.com/go-swagger/go-swagger
+  version: fbc64c262a833b40adf3d2cdba241fc4d30664b0
+  subpackages:
+  - cmd/swagger
 - name: github.com/go-zoo/bone
   version: fd0aebc74e908868b09ac140fb5a53cb363884c1
+- name: github.com/golang/lint
+  version: cb00e5669539f047b2f4c53a421a01b0c8e172c6
+  subpackages:
+  - golint
+- name: github.com/gordonklaus/ineffassign
+  version: f0c5cfc1817d6dd6011c7e8b8d272f94aeeb12cb
 - name: github.com/mailru/easyjson
   version: 2af9a745a611440bab0528e5ac19b2805a1c50eb
   subpackages:
@@ -52,14 +68,14 @@ imports:
 - name: github.com/manifoldco/go-jwt
   version: f2e996517b3d7de4f17b8bbfa64d2d396f302bb1
 - name: github.com/manifoldco/go-manifold
-  version: 640d3e7b9f9e858924b1b3e6c17ced1bc256c014
+  version: 55004bd59e68290faa825ca968025d2b1d9ab2e9
   subpackages:
   - errors
   - idtype
 - name: github.com/manifoldco/go-signature
   version: b948ef70772bc297c188970439dc479230833597
 - name: github.com/manifoldco/torus-cli
-  version: fbd3a2449dd62529ec5ab07cf1e49bc85c69459a
+  version: c44a71127d9dcfcf1d03b0be5942385ca66d07f6
   subpackages:
   - promptui
 - name: github.com/mitchellh/mapstructure
@@ -82,6 +98,8 @@ imports:
   version: 0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4
 - name: github.com/PuerkitoBio/urlesc
   version: bbf7a2afc14f93e1e0a5c06df524fbd75e5031e5
+- name: github.com/tsenart/deadcode
+  version: 210d2dc333e90c7e3eedf4f2242507a8e83ed4ab
 - name: github.com/urfave/cli
   version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
 - name: golang.org/x/crypto
@@ -107,6 +125,10 @@ imports:
   - unicode/bidi
   - unicode/norm
   - width
+- name: golang.org/x/tools
+  version: bc6db94186c03835daa5c1c679fba599dc1f3b79
+  subpackages:
+  - go/gcexportdata
 - name: gopkg.in/mgo.v2
   version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -21,3 +21,20 @@ import:
 - package: golang.org/x/crypto
   subpackages:
   - ed25519
+- package: github.com/client9/misspell
+  subpackages:
+  - cmd/misspell
+- package: github.com/golang/lint
+  subpackages:
+  - golint
+- package: github.com/gordonklaus/ineffassign
+- package: github.com/tsenart/deadcode
+- package: github.com/alecthomas/gometalinter
+  version: ^1.2.1
+- package: github.com/go-swagger/go-swagger
+  version: fbc64c262a833b40adf3d2cdba241fc4d30664b0
+  subpackages:
+  - cmd/swagger
+- package: golang.org/x/tools
+  subpackages:
+  - go/gcexportdata


### PR DESCRIPTION
Grafton now validates whether or not the credential names it's receiving
back are valid. They must be valid names in accordance with Shell and
Utilities volume of IEEE Std 1003.1-2001.

A function is also exported for use by client libraries.