### PR TITLE
Fix acceptance tests; check for correct error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   testing whether or not a given credential name is valid.
 - Dependencies for bootstrapping the build are now vendored using glide.
 
+### Fixes
+
+- A bug has been fixed which resulted in all of the error acceptance tests
+  failing despite the response returned from the provider.
+
 ## [0.8.0] - 2017-05-14
 
 ### Improvements

--- a/acceptance/credentials.go
+++ b/acceptance/credentials.go
@@ -8,11 +8,11 @@ import (
 	gm "github.com/onsi/gomega"
 
 	"github.com/manifoldco/go-manifold"
+	merrors "github.com/manifoldco/go-manifold/errors"
 	"github.com/manifoldco/go-manifold/idtype"
 
 	"github.com/manifoldco/grafton"
 	"github.com/manifoldco/grafton/connector"
-	"github.com/manifoldco/grafton/generated/provider/client/credential"
 )
 
 var credentialID manifold.ID
@@ -71,9 +71,12 @@ var creds = Feature("credentials", "Create a credential set", func(ctx context.C
 			"Expected an error, got nil",
 		)
 		gm.Expect(err).Should(
-			gm.BeAssignableToTypeOf(&credential.PutCredentialsIDNotFound{}),
-			"Expected an IDNotFound error, got %T", err,
+			gm.BeAssignableToTypeOf(&grafton.Error{}),
+			"Expected a grafton error, got %T", err,
 		)
+
+		e := err.(*grafton.Error)
+		gm.Expect(e.Type).Should(gm.Equal(merrors.NotFoundError))
 	})
 
 	ErrorCase("with already provisioned credentials - same content acts as created", func() {
@@ -108,9 +111,12 @@ var creds = Feature("credentials", "Create a credential set", func(ctx context.C
 			"Expected an error, got nil",
 		)
 		gm.Expect(err).Should(
-			gm.BeAssignableToTypeOf(&credential.PutCredentialsIDUnauthorized{}),
-			"Expected an Unauthorized error, got %T", err,
+			gm.BeAssignableToTypeOf(&grafton.Error{}),
+			"Expected a grafton error, got %T", err,
 		)
+
+		e := err.(*grafton.Error)
+		gm.Expect(e.Type).Should(gm.Equal(merrors.UnauthorizedError))
 	})
 })
 
@@ -155,9 +161,12 @@ var _ = creds.TearDown("Delete a credential set", func(ctx context.Context) {
 			"Expected an error, got nil",
 		)
 		gm.Expect(err).Should(
-			gm.BeAssignableToTypeOf(&credential.DeleteCredentialsIDNotFound{}),
-			"Expected a CredentialsIDNotFound error, got %T", err,
+			gm.BeAssignableToTypeOf(&grafton.Error{}),
+			"Expected a grafton error, got %T", err,
 		)
+
+		e := err.(*grafton.Error)
+		gm.Expect(e.Type).Should(gm.Equal(merrors.NotFoundError))
 	})
 })
 

--- a/acceptance/provision.go
+++ b/acceptance/provision.go
@@ -9,11 +9,11 @@ import (
 	gm "github.com/onsi/gomega"
 
 	"github.com/manifoldco/go-manifold"
+	merrors "github.com/manifoldco/go-manifold/errors"
 	"github.com/manifoldco/go-manifold/idtype"
 
 	"github.com/manifoldco/grafton"
 	"github.com/manifoldco/grafton/connector"
-	"github.com/manifoldco/grafton/generated/provider/client/resource"
 )
 
 var errTimeout = errors.New("Exceeded Callback Wait time")
@@ -63,9 +63,12 @@ var provision = Feature("provision", "Provision a resource", func(ctx context.Co
 			"Expected an error, got nil",
 		)
 		gm.Expect(err).Should(
-			gm.BeAssignableToTypeOf(&resource.PutResourcesIDBadRequest{}),
-			"Expected a BadRequest error, got %T", err,
+			gm.BeAssignableToTypeOf(&grafton.Error{}),
+			"Expected a grafton error, got %T", err,
 		)
+
+		e := err.(*grafton.Error)
+		gm.Expect(e.Type).Should(gm.Equal(merrors.BadRequestError))
 	})
 
 	ErrorCase("with a faulty plan name", func() {
@@ -83,9 +86,12 @@ var provision = Feature("provision", "Provision a resource", func(ctx context.Co
 			"Expected an error, got nil",
 		)
 		gm.Expect(err).Should(
-			gm.BeAssignableToTypeOf(&resource.PutResourcesIDBadRequest{}),
-			"Expected a BadRequest error, got %T", err,
+			gm.BeAssignableToTypeOf(&grafton.Error{}),
+			"Expected a grafton error, got %T", err,
 		)
+
+		e := err.(*grafton.Error)
+		gm.Expect(e.Type).Should(gm.Equal(merrors.BadRequestError))
 	})
 
 	ErrorCase("with a faulty region", func() {
@@ -103,9 +109,12 @@ var provision = Feature("provision", "Provision a resource", func(ctx context.Co
 			"Expected an error, got nil",
 		)
 		gm.Expect(err).Should(
-			gm.BeAssignableToTypeOf(&resource.PutResourcesIDBadRequest{}),
-			"Expected a BadRequest error, got %T", err,
+			gm.BeAssignableToTypeOf(&grafton.Error{}),
+			"Expected a grafton error, got %T", err,
 		)
+
+		e := err.(*grafton.Error)
+		gm.Expect(e.Type).Should(gm.Equal(merrors.BadRequestError))
 	})
 
 	ErrorCase("with a bad signature", func() {
@@ -122,10 +131,14 @@ var provision = Feature("provision", "Provision a resource", func(ctx context.Co
 			gm.BeNil(),
 			"Expected an error, got nil",
 		)
+
 		gm.Expect(err).Should(
-			gm.BeAssignableToTypeOf(&resource.PutResourcesIDUnauthorized{}),
-			"Expected an Unauthorized error, got %T", err,
+			gm.BeAssignableToTypeOf(&grafton.Error{}),
+			"Expected a grafton error, got %T", err,
 		)
+
+		e := err.(*grafton.Error)
+		gm.Expect(e.Type).Should(gm.Equal(merrors.UnauthorizedError))
 	})
 
 	ErrorCase("with an already provisioned resource - same content acts as created", func() {
@@ -156,9 +169,12 @@ var provision = Feature("provision", "Provision a resource", func(ctx context.Co
 			"Expected an error, got nil",
 		)
 		gm.Expect(err).Should(
-			gm.BeAssignableToTypeOf(&resource.PutResourcesIDConflict{}),
-			"Expected a 409 Conflict error, got %T (Repeated Action)", err,
+			gm.BeAssignableToTypeOf(&grafton.Error{}),
+			"Expected a grafton error, got %T", err,
 		)
+
+		e := err.(*grafton.Error)
+		gm.Expect(e.Type).Should(gm.Equal(merrors.ConflictError))
 	})
 })
 
@@ -202,9 +218,12 @@ var _ = provision.TearDown("Deprovision a resource", func(ctx context.Context) {
 			"Expected an error, got nil",
 		)
 		gm.Expect(err).Should(
-			gm.BeAssignableToTypeOf(&resource.DeleteResourcesIDNotFound{}),
-			"Expected a resource NotFound error, got %T", err,
+			gm.BeAssignableToTypeOf(&grafton.Error{}),
+			"Expected a grafton error, got %T", err,
 		)
+
+		e := err.(*grafton.Error)
+		gm.Expect(e.Type).Should(gm.Equal(merrors.NotFoundError))
 	})
 })
 var _ = provision.RequiredFlags("product", "plan", "region", "new-plan")

--- a/acceptance/resize.go
+++ b/acceptance/resize.go
@@ -8,11 +8,11 @@ import (
 	gm "github.com/onsi/gomega"
 
 	"github.com/manifoldco/go-manifold"
+	merrors "github.com/manifoldco/go-manifold/errors"
 	"github.com/manifoldco/go-manifold/idtype"
 
 	"github.com/manifoldco/grafton"
 	"github.com/manifoldco/grafton/connector"
-	"github.com/manifoldco/grafton/generated/provider/client/resource"
 )
 
 var resize = Feature("plan-change", "Change a resource's plan", func(ctx context.Context) {
@@ -68,9 +68,12 @@ var resize = Feature("plan-change", "Change a resource's plan", func(ctx context
 			"Expected an error, got nil",
 		)
 		gm.Expect(err).Should(
-			gm.BeAssignableToTypeOf(&resource.PatchResourcesIDNotFound{}),
-			"Expected a IDNotFound error, got %T", err,
+			gm.BeAssignableToTypeOf(&grafton.Error{}),
+			"Expected a grafton error, got %T", err,
 		)
+
+		e := err.(*grafton.Error)
+		gm.Expect(e.Type).Should(gm.Equal(merrors.NotFoundError))
 	})
 
 	ErrorCase("with a non existing plan", func() {
@@ -88,9 +91,12 @@ var resize = Feature("plan-change", "Change a resource's plan", func(ctx context
 			"Expected an error, got nil",
 		)
 		gm.Expect(err).Should(
-			gm.BeAssignableToTypeOf(&resource.PatchResourcesIDBadRequest{}),
-			"Expected a BadRequest error, got %T", err,
+			gm.BeAssignableToTypeOf(&grafton.Error{}),
+			"Expected a grafton error, got %T", err,
 		)
+
+		e := err.(*grafton.Error)
+		gm.Expect(e.Type).Should(gm.Equal(merrors.BadRequestError))
 	})
 
 	ErrorCase("with a bad signature", func() {
@@ -108,9 +114,12 @@ var resize = Feature("plan-change", "Change a resource's plan", func(ctx context
 			"Expected an error, got nil",
 		)
 		gm.Expect(err).Should(
-			gm.BeAssignableToTypeOf(&resource.PatchResourcesIDUnauthorized{}),
-			"Expected an Unauthorized error, got %T", err,
+			gm.BeAssignableToTypeOf(&grafton.Error{}),
+			"Expected a grafton error, got %T", err,
 		)
+
+		e := err.(*grafton.Error)
+		gm.Expect(e.Type).Should(gm.Equal(merrors.UnauthorizedError))
 	})
 })
 

--- a/acceptance/sso.go
+++ b/acceptance/sso.go
@@ -63,7 +63,7 @@ var sso = Feature("sso", "Single Sign-On Flow", func(ctx context.Context) {
 			}
 		}
 
-		gm.Expect(len(reqs)).To(gm.Equal(1), "Zero or more than one token request received")
+		gm.Expect(len(reqs)).To(gm.Equal(1), "Zero or more than one token request should be received")
 		tokReq := reqs[0].(*connector.TokenRequest)
 		gm.Expect(tokReq).To(matchTokenRequest(&connector.TokenRequest{
 			ContentType:  "application/x-www-form-urlencoded",


### PR DESCRIPTION
As a result of the work done to always return a `grafton.Error` from the
grafton client, the acceptance tests were broken.

I've updated the tests appropriately!