### PR TITLE
Add optional logger to Grafton and differentiate errors from messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Improvements
 
-- The Grafton Client now returns an `ErrMissingMsg` on a `200`, `201`, or `202`
-  request missing a `message` property.
 - Introduced the cleanup acceptance test set, which tests to ensure any
   half-created resources can be cleaned up.
 - Added a teardown step to the resize acceptance tests, ensuring a resource can
   be resized back to it's original plan.
+- The Grafton Client now returns an `ErrMissingMsg` on a `200`, `201`, or `202`
+  request missing a `message` property.
+- The Grafton client now differentiates between an error and a message returned
+  from the provider, a message will be returned if a provider sends a valid
+  message despite whether or not it was an error response.
+- The Grafton client now takes a `logrus.Entry`, when provided Grafton will
+  push error logs to the provided logger.
 
 ## [0.9.0] - 2017-06-01
 

--- a/client.go
+++ b/client.go
@@ -42,6 +42,9 @@ func New(url *nurl.URL, connectorURL *nurl.URL, signer Signer) *Client {
 }
 
 // ProvisionResource makes a resource provisioning call.
+//
+// A message will be returned if a callback was used *or* a provider returned
+// an error with an explanation.
 func (c *Client) ProvisionResource(ctx context.Context, cbID, resID manifold.ID, product, plan, region string) (string, bool, error) {
 
 	body := models.ResourceRequest{
@@ -77,7 +80,11 @@ func (c *Client) ProvisionResource(ctx context.Context, cbID, resID manifold.ID,
 			return "", false, err
 		}
 
-		return "", false, graftonErr
+		if graftonErr == ErrMissingMsg {
+			return "", false, graftonErr
+		}
+
+		return graftonErr.Error(), false, graftonErr
 	}
 
 	var msgPtr *string
@@ -110,6 +117,9 @@ func deriveCallbackURL(connectorURL *nurl.URL, cbID manifold.ID) (string, error)
 }
 
 // ProvisionCredentials makes a credential provisioning call.
+//
+// A message will be returned if a callback was used *or* a provider returned
+// an error with an explanation.
 func (c *Client) ProvisionCredentials(ctx context.Context, cbID, resID, credID manifold.ID) (map[string]string, string, bool, error) {
 	body := models.CredentialRequest{
 		ID:         credID,
@@ -145,7 +155,11 @@ func (c *Client) ProvisionCredentials(ctx context.Context, cbID, resID, credID m
 			return nil, "", false, err
 		}
 
-		return nil, "", false, graftonErr
+		if graftonErr == ErrMissingMsg {
+			return nil, "", false, graftonErr
+		}
+
+		return nil, graftonErr.Error(), false, graftonErr
 	}
 
 	var msgPtr *string
@@ -167,6 +181,9 @@ func (c *Client) ProvisionCredentials(ctx context.Context, cbID, resID, credID m
 }
 
 // ChangePlan makes a patch call to change the resource's plan.
+//
+// A message will be returned if a callback was used *or* a provider returned
+// an error with an explanation.
 func (c *Client) ChangePlan(ctx context.Context, cbID, resourceID manifold.ID, newPlan string) (string, bool, error) {
 	body := models.ResourcePlanChangeRequest{Plan: manifold.Label(newPlan)}
 
@@ -196,7 +213,11 @@ func (c *Client) ChangePlan(ctx context.Context, cbID, resourceID manifold.ID, n
 			return "", false, err
 		}
 
-		return "", false, graftonErr
+		if graftonErr == ErrMissingMsg {
+			return "", false, graftonErr
+		}
+
+		return graftonErr.Error(), false, graftonErr
 	}
 
 	var msgPtr *string
@@ -217,7 +238,8 @@ func (c *Client) ChangePlan(ctx context.Context, cbID, resourceID manifold.ID, n
 
 // DeprovisionCredentials deletes credentials from the remote provider.
 //
-// A message will be presented if a callback is provided
+// A message will be presented if a callback is provided or if a message was
+// returned from the provider due to an error.
 func (c *Client) DeprovisionCredentials(ctx context.Context, cbID, credentialID manifold.ID) (string, bool, error) {
 	msg := ""
 	cbURL, err := deriveCallbackURL(c.connectorURL, cbID)
@@ -246,8 +268,11 @@ func (c *Client) DeprovisionCredentials(ctx context.Context, cbID, credentialID 
 			return "", false, err
 		}
 
-		return "", false, graftonErr
+		if graftonErr == ErrMissingMsg {
+			return "", false, graftonErr
+		}
 
+		return graftonErr.Error(), false, graftonErr
 	}
 
 	callback := accepted != nil
@@ -263,6 +288,9 @@ func (c *Client) DeprovisionCredentials(ctx context.Context, cbID, credentialID 
 }
 
 // DeprovisionResource deletes resources from the remote provider.
+//
+// A message will be returned if a callback was used *or* a provider returned
+// an error with an explanation.
 func (c *Client) DeprovisionResource(ctx context.Context, cbID, resourceID manifold.ID) (string, bool, error) {
 	msg := ""
 	cbURL, err := deriveCallbackURL(c.connectorURL, cbID)
@@ -291,7 +319,11 @@ func (c *Client) DeprovisionResource(ctx context.Context, cbID, resourceID manif
 			return "", false, err
 		}
 
-		return "", false, graftonErr
+		if graftonErr == ErrMissingMsg {
+			return "", false, graftonErr
+		}
+
+		return graftonErr.Error(), false, graftonErr
 	}
 
 	callback := accepted != nil

--- a/client_test.go
+++ b/client_test.go
@@ -228,8 +228,9 @@ func TestProvisionResource(t *testing.T) {
 	})
 
 	t.Run("400 bad request valid response", withCode(http.StatusBadRequest, func(url string) {
-		_, _, err := callProvision(url)
+		msg, _, err := callProvision(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.BadRequestError, "i dont get ya")))
 	}))
 
@@ -242,8 +243,9 @@ func TestProvisionResource(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, _, err := callProvision(srv.URL)
+		msg, _, err := callProvision(srv.URL)
 
+		gm.Expect(msg).To(gm.Equal(""))
 		gm.Expect(err).To(gm.MatchError(`no consumer: "text/html"`))
 	})
 
@@ -256,28 +258,37 @@ func TestProvisionResource(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, _, err := callProvision(srv.URL)
+		msg, _, err := callProvision(srv.URL)
 
+		gm.Expect(msg).To(gm.Equal(""))
 		gm.Expect(err).To(gm.MatchError(ErrMissingMsg))
 	})
 
 	t.Run("401 unauthorized valid response", withCode(http.StatusUnauthorized, func(url string) {
-		_, _, err := callProvision(url)
+		msg, _, err := callProvision(url)
+
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.UnauthorizedError, "i dont get ya")))
 	}))
 
 	t.Run("409 conflict valid response", withCode(http.StatusConflict, func(url string) {
-		_, _, err := callProvision(url)
+		msg, _, err := callProvision(url)
+
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.ConflictError, "i dont get ya")))
 	}))
 
 	t.Run("500 internal server error valid response", withCode(http.StatusInternalServerError, func(url string) {
-		_, _, err := callProvision(url)
+		msg, _, err := callProvision(url)
+
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.InternalServerError, "i dont get ya")))
 	}))
 
 	t.Run("503 service unavailable, unrecognized status code", withCode(http.StatusServiceUnavailable, func(url string) {
-		_, _, err := callProvision(url)
+		msg, _, err := callProvision(url)
+
+		gm.Expect(msg).To(gm.Equal(""))
 		gm.Expect(IsFatal(err)).To(gm.BeFalse())
 	}))
 
@@ -291,8 +302,9 @@ func TestProvisionResource(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, _, err := callProvision(srv.URL)
+		msg, _, err := callProvision(srv.URL)
 
+		gm.Expect(msg).To(gm.Equal(""))
 		gm.Expect(IsFatal(err)).To(gm.BeFalse())
 	})
 }
@@ -372,14 +384,16 @@ func TestProvisionCredentials(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, _, _, err := callProvisionCredentials(srv.URL)
+		_, msg, _, err := callProvisionCredentials(srv.URL)
 
+		gm.Expect(msg).To(gm.Equal(""))
 		gm.Expect(err).To(gm.MatchError(ErrMissingMsg))
 	})
 
 	t.Run("400 bad request valid response", withCode(http.StatusBadRequest, func(url string) {
-		_, _, _, err := callProvisionCredentials(url)
+		_, msg, _, err := callProvisionCredentials(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.BadRequestError, "i dont get ya")))
 	}))
 
@@ -392,8 +406,9 @@ func TestProvisionCredentials(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, _, _, err := callProvisionCredentials(srv.URL)
+		_, msg, _, err := callProvisionCredentials(srv.URL)
 
+		gm.Expect(msg).To(gm.Equal(""))
 		gm.Expect(err).To(gm.MatchError(`no consumer: "text/html"`))
 	})
 
@@ -406,26 +421,30 @@ func TestProvisionCredentials(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, _, _, err := callProvisionCredentials(srv.URL)
+		_, msg, _, err := callProvisionCredentials(srv.URL)
 
+		gm.Expect(msg).To(gm.Equal(""))
 		gm.Expect(err).To(gm.MatchError(ErrMissingMsg))
 	})
 
 	t.Run("404 not found valid response", withCode(http.StatusNotFound, func(url string) {
-		_, _, _, err := callProvisionCredentials(url)
+		_, msg, _, err := callProvisionCredentials(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.NotFoundError, "i dont get ya")))
 	}))
 
 	t.Run("409 conflict valid response", withCode(http.StatusConflict, func(url string) {
-		_, _, _, err := callProvisionCredentials(url)
+		_, msg, _, err := callProvisionCredentials(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.ConflictError, "i dont get ya")))
 	}))
 
 	t.Run("500 internal server error valid response", withCode(http.StatusInternalServerError, func(url string) {
-		_, _, _, err := callProvisionCredentials(url)
+		_, msg, _, err := callProvisionCredentials(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.InternalServerError, "i dont get ya")))
 	}))
 }
@@ -503,8 +522,9 @@ func TestChangePlan(t *testing.T) {
 	})
 
 	t.Run("400 bad request valid response", withCode(http.StatusBadRequest, func(url string) {
-		_, _, err := callChangePlan(url)
+		msg, _, err := callChangePlan(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.BadRequestError, "i dont get ya")))
 	}))
 
@@ -517,7 +537,9 @@ func TestChangePlan(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, _, err := callChangePlan(srv.URL)
+		msg, _, err := callChangePlan(srv.URL)
+
+		gm.Expect(msg).To(gm.Equal(""))
 		gm.Expect(err).To(gm.MatchError(`no consumer: "text/html"`))
 	})
 
@@ -530,26 +552,30 @@ func TestChangePlan(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, _, err := callChangePlan(srv.URL)
+		msg, _, err := callChangePlan(srv.URL)
 
+		gm.Expect(msg).To(gm.Equal(""))
 		gm.Expect(err).To(gm.MatchError(ErrMissingMsg))
 	})
 
 	t.Run("401 bad unauthorized valid response", withCode(http.StatusUnauthorized, func(url string) {
-		_, _, err := callChangePlan(url)
+		msg, _, err := callChangePlan(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.UnauthorizedError, "i dont get ya")))
 	}))
 
 	t.Run("404 not found valid response", withCode(http.StatusNotFound, func(url string) {
-		_, _, err := callChangePlan(url)
+		msg, _, err := callChangePlan(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.NotFoundError, "i dont get ya")))
 	}))
 
 	t.Run("500 internal server error valid response", withCode(http.StatusInternalServerError, func(url string) {
-		_, _, err := callChangePlan(url)
+		msg, _, err := callChangePlan(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.InternalServerError, "i dont get ya")))
 	}))
 }
@@ -590,8 +616,9 @@ func TestDeprovisionCredentials(t *testing.T) {
 	})
 
 	t.Run("400 bad request error valid response", withCode(http.StatusBadRequest, func(url string) {
-		_, _, err := callDeprovisionCredentials(url)
+		msg, _, err := callDeprovisionCredentials(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.BadRequestError, "i dont get ya")))
 	}))
 
@@ -604,8 +631,9 @@ func TestDeprovisionCredentials(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, _, err := callDeprovisionCredentials(srv.URL)
+		msg, _, err := callDeprovisionCredentials(srv.URL)
 
+		gm.Expect(msg).To(gm.Equal(""))
 		gm.Expect(err).To(gm.MatchError(`no consumer: "text/html"`))
 	})
 
@@ -618,26 +646,30 @@ func TestDeprovisionCredentials(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, _, err := callDeprovisionCredentials(srv.URL)
+		msg, _, err := callDeprovisionCredentials(srv.URL)
 
+		gm.Expect(msg).To(gm.Equal(""))
 		gm.Expect(err).To(gm.MatchError(ErrMissingMsg))
 	})
 
 	t.Run("401 unauthorized valid response", withCode(http.StatusUnauthorized, func(url string) {
-		_, _, err := callDeprovisionCredentials(url)
+		msg, _, err := callDeprovisionCredentials(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.UnauthorizedError, "i dont get ya")))
 	}))
 
 	t.Run("404 not found valid response", withCode(http.StatusNotFound, func(url string) {
-		_, _, err := callDeprovisionCredentials(url)
+		msg, _, err := callDeprovisionCredentials(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.NotFoundError, "i dont get ya")))
 	}))
 
 	t.Run("500 internal server error valid response", withCode(http.StatusInternalServerError, func(url string) {
-		_, _, err := callDeprovisionCredentials(url)
+		msg, _, err := callDeprovisionCredentials(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.InternalServerError, "i dont get ya")))
 	}))
 }
@@ -678,8 +710,9 @@ func TestDeprovisionResource(t *testing.T) {
 	})
 
 	t.Run("400 bad request valid response", withCode(http.StatusBadRequest, func(url string) {
-		_, _, err := callDeprovisionResource(url)
+		msg, _, err := callDeprovisionResource(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.BadRequestError, "i dont get ya")))
 	}))
 
@@ -692,8 +725,9 @@ func TestDeprovisionResource(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, _, err := callDeprovisionResource(srv.URL)
+		msg, _, err := callDeprovisionResource(srv.URL)
 
+		gm.Expect(msg).To(gm.Equal(""))
 		gm.Expect(err).To(gm.MatchError(`no consumer: "text/html"`))
 	})
 
@@ -706,26 +740,30 @@ func TestDeprovisionResource(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		_, _, err := callDeprovisionResource(srv.URL)
+		msg, _, err := callDeprovisionResource(srv.URL)
 
+		gm.Expect(msg).To(gm.Equal(""))
 		gm.Expect(err).To(gm.MatchError(ErrMissingMsg))
 	})
 
 	t.Run("400 unauthorized valid response", withCode(http.StatusUnauthorized, func(url string) {
-		_, _, err := callDeprovisionResource(url)
+		msg, _, err := callDeprovisionResource(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.UnauthorizedError, "i dont get ya")))
 	}))
 
 	t.Run("404 not found valid response", withCode(http.StatusNotFound, func(url string) {
-		_, _, err := callDeprovisionResource(url)
+		msg, _, err := callDeprovisionResource(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.NotFoundError, "i dont get ya")))
 	}))
 
 	t.Run("500 internal server error valid response", withCode(http.StatusInternalServerError, func(url string) {
-		_, _, err := callDeprovisionResource(url)
+		msg, _, err := callDeprovisionResource(url)
 
+		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.InternalServerError, "i dont get ya")))
 	}))
 }

--- a/client_test.go
+++ b/client_test.go
@@ -22,7 +22,7 @@ func (stubSigner) Sign([]byte) (*signature.Signature, error) { return &signature
 func callProvision(rawURL string) (string, bool, error) {
 	ctx := context.Background()
 	sURL, _ := url.Parse(rawURL)
-	c := New(sURL, &url.URL{}, stubSigner{})
+	c := New(sURL, &url.URL{}, stubSigner{}, nil)
 
 	cbID := manifold.ID{}
 	resID := manifold.ID{}
@@ -32,7 +32,7 @@ func callProvision(rawURL string) (string, bool, error) {
 func callProvisionCredentials(rawURL string) (map[string]string, string, bool, error) {
 	ctx := context.Background()
 	sURL, _ := url.Parse(rawURL)
-	c := New(sURL, &url.URL{}, stubSigner{})
+	c := New(sURL, &url.URL{}, stubSigner{}, nil)
 
 	cbID := manifold.ID{}
 	resID := manifold.ID{}
@@ -43,7 +43,7 @@ func callProvisionCredentials(rawURL string) (map[string]string, string, bool, e
 func callChangePlan(rawURL string) (string, bool, error) {
 	ctx := context.Background()
 	sURL, _ := url.Parse(rawURL)
-	c := New(sURL, &url.URL{}, stubSigner{})
+	c := New(sURL, &url.URL{}, stubSigner{}, nil)
 
 	cbID := manifold.ID{}
 	resID := manifold.ID{}
@@ -55,7 +55,7 @@ func callDeprovisionCredentials(rawURL string) (string, bool, error) {
 	ctx := context.Background()
 	sURL, _ := url.Parse(rawURL)
 
-	c := New(sURL, &url.URL{}, stubSigner{})
+	c := New(sURL, &url.URL{}, stubSigner{}, nil)
 
 	cbID := manifold.ID{}
 	credID := manifold.ID{}
@@ -67,7 +67,7 @@ func callDeprovisionResource(rawURL string) (string, bool, error) {
 	ctx := context.Background()
 	sURL, _ := url.Parse(rawURL)
 
-	c := New(sURL, &url.URL{}, stubSigner{})
+	c := New(sURL, &url.URL{}, stubSigner{}, nil)
 
 	cbID := manifold.ID{}
 	resID := manifold.ID{}
@@ -105,7 +105,7 @@ func testCreateSSOURL(base, code string) (string, manifold.ID, error) {
 		return "", ID, err
 	}
 
-	c := New(u, &url.URL{}, stubSigner{})
+	c := New(u, &url.URL{}, stubSigner{}, nil)
 	return c.CreateSsoURL(code, ID).String(), ID, nil
 }
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -148,13 +148,13 @@ func testCmd(ctx *cli.Context) error {
 	}
 
 	connectorURL := deriveConnectorURL(connectorPort)
-	api := grafton.New(purl, connectorURL, lkp)
+	api := grafton.New(purl, connectorURL, lkp, nil)
 
 	fkp, err := emptyKeypair()
 	if err != nil {
 		return cli.NewExitError("Could not create request empty signing keypair: "+err.Error(), -1)
 	}
-	unauthorizedAPI := grafton.New(purl, connectorURL, fkp)
+	unauthorizedAPI := grafton.New(purl, connectorURL, fkp, nil)
 	c := context.Background()
 
 	willChangePlan := false

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 0691276178654320a4652dedc01fc6563a10c20636ff11316aaab8c2a0939a0e
-updated: 2017-05-29T16:42:23.985162557-03:00
+hash: 43fafcb6bddc9526327502742540c363b84b34ec341bc4f2cba5f78c62f35c57
+updated: 2017-06-17T21:09:33.652043062-03:00
 imports:
 - name: github.com/alecthomas/gometalinter
   version: bae2f1293d092fd8167939d5108d1b025eaef9de
@@ -75,7 +75,7 @@ imports:
 - name: github.com/manifoldco/go-signature
   version: b948ef70772bc297c188970439dc479230833597
 - name: github.com/manifoldco/torus-cli
-  version: c44a71127d9dcfcf1d03b0be5942385ca66d07f6
+  version: 6968117466a156652a246a59301cd58310e5e965
   subpackages:
   - promptui
 - name: github.com/mitchellh/mapstructure
@@ -98,6 +98,8 @@ imports:
   version: 0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4
 - name: github.com/PuerkitoBio/urlesc
   version: bbf7a2afc14f93e1e0a5c06df524fbd75e5031e5
+- name: github.com/Sirupsen/logrus
+  version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/tsenart/deadcode
   version: 210d2dc333e90c7e3eedf4f2242507a8e83ed4ab
 - name: github.com/urfave/cli

--- a/glide.yaml
+++ b/glide.yaml
@@ -38,3 +38,4 @@ import:
 - package: golang.org/x/tools
   subpackages:
   - go/gcexportdata
+- package: github.com/Sirupsen/logrus


### PR DESCRIPTION
The Grafton client now differentiates between an error and a message returned  from the provider, a message will be returned if a provider sends a valid message despite whether or not it was an error response.

In addition, the client now takes a `logrus.Entry` struct which will be pushed error logs.