### PR TITLE
Add cleanup feature and resize teardown tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - The Grafton Client now returns an `ErrMissingMsg` on a `200`, `201`, or `202`
   request missing a `message` property.
+- Introduced the cleanup acceptance test set, which tests to ensure any
+  half-created resources can be cleaned up.
+- Added a teardown step to the resize acceptance tests, ensuring a resource can
+  be resized back to it's original plan.
 
 ## [0.9.0] - 2017-06-01
 

--- a/acceptance/cleanup.go
+++ b/acceptance/cleanup.go
@@ -1,0 +1,16 @@
+package acceptance
+
+import (
+	"context"
+	"time"
+)
+
+var _ = Feature("cleanup", "Remove dangling resource due to failed provision", func(ctx context.Context) {
+	Default(func() {
+		ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		defer cancel()
+
+		curResource := attemptResourceProvision(ctx, api, product, plan, region)
+		attemptResourceDeprovision(ctx, api, curResource.ID)
+	})
+})


### PR DESCRIPTION
As a part of continued work inside Manifold's platform, we are beginning
to add rollback and cleanup phases to the provisioning and resize
operations.

During a provision, we may need to delete a resource *before* we
complete the flow (which includes creating a set of credentials). This
was not explicitly tested as a part of Grafton, so we've added a test.
It's also possible for something to wrong after creation of a credential
set has completed, however, this would resemble a normal deprovision
which is already tested.

In the case of resize, it's possible that something could go wrong on
Manifold's side after the resize was successful. At which point,
Manifold would then resize the instance back to the original state.