### PR TITLE
Add tests for 500 Response w/ no body

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -299,6 +299,21 @@ func TestProvisionResource(t *testing.T) {
 		gm.Expect(err).To(gm.MatchError(NewError(errors.InternalServerError, "i dont get ya")))
 	}))
 
+	t.Run("500 internal server error no body", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		msg, async, err := callProvision(srv.URL)
+
+		gm.Expect(msg).To(gm.Equal(""))
+		gm.Expect(IsFatal(err)).To(gm.BeFalse())
+		gm.Expect(async).To(gm.BeFalse())
+	})
+
 	t.Run("503 service unavailable, unrecognized status code", withCode(http.StatusServiceUnavailable, func(url string) {
 		msg, _, err := callProvision(url)
 
@@ -461,6 +476,21 @@ func TestProvisionCredentials(t *testing.T) {
 		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.InternalServerError, "i dont get ya")))
 	}))
+
+	t.Run("500 internal server error no body", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		_, msg, async, err := callProvisionCredentials(srv.URL)
+
+		gm.Expect(msg).To(gm.Equal(""))
+		gm.Expect(IsFatal(err)).To(gm.BeFalse())
+		gm.Expect(async).To(gm.BeFalse())
+	})
 }
 
 func TestChangePlan(t *testing.T) {
@@ -606,6 +636,21 @@ func TestChangePlan(t *testing.T) {
 		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.InternalServerError, "i dont get ya")))
 	}))
+
+	t.Run("500 internal server error no body", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		msg, async, err := callChangePlan(srv.URL)
+
+		gm.Expect(msg).To(gm.Equal(""))
+		gm.Expect(IsFatal(err)).To(gm.BeFalse())
+		gm.Expect(async).To(gm.BeFalse())
+	})
 }
 
 func TestDeprovisionCredentials(t *testing.T) {
@@ -714,6 +759,21 @@ func TestDeprovisionCredentials(t *testing.T) {
 		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.InternalServerError, "i dont get ya")))
 	}))
+
+	t.Run("500 internal server error no body", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		msg, async, err := callDeprovisionCredentials(srv.URL)
+
+		gm.Expect(msg).To(gm.Equal(""))
+		gm.Expect(IsFatal(err)).To(gm.BeFalse())
+		gm.Expect(async).To(gm.BeFalse())
+	})
 }
 
 func TestDeprovisionResource(t *testing.T) {
@@ -822,4 +882,19 @@ func TestDeprovisionResource(t *testing.T) {
 		gm.Expect(msg).To(gm.Equal("i dont get ya"))
 		gm.Expect(err).To(gm.MatchError(NewError(errors.InternalServerError, "i dont get ya")))
 	}))
+
+	t.Run("500 internal server error no body", func(t *testing.T) {
+		gm.RegisterTestingT(t)
+
+		srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		msg, async, err := callDeprovisionResource(srv.URL)
+
+		gm.Expect(msg).To(gm.Equal(""))
+		gm.Expect(IsFatal(err)).To(gm.BeFalse())
+		gm.Expect(async).To(gm.BeFalse())
+	})
 }


### PR DESCRIPTION
It's common for load balancers and other services to return 500 errors
without any bodies. We don't have any test coverage, so I quickly added
some while I was tracking down another bug.