### PR TITLE
Message is not required for 201 Cred Prov. Resp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [x.y.z] - YYYY-MM-DD (Unreleased)
 
+## Fixes
+
+- Grafton no longer errors if a `message` is not provided with a 201 Created
+  response to a credential provisioning request.
+
 ## [0.10.1] - 2017-06-26
 
 ### Fixes

--- a/client_test.go
+++ b/client_test.go
@@ -356,8 +356,8 @@ func TestProvisionCredentials(t *testing.T) {
 		creds, message, async, err := callProvisionCredentials(srv.URL)
 
 		gm.Expect(message).To(gm.Equal(""))
-		gm.Expect(err).To(gm.MatchError(ErrMissingMsg))
-		gm.Expect(creds).To(gm.BeNil())
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+		gm.Expect(creds).To(gm.Equal(map[string]string{"foo": "bar"}))
 		gm.Expect(async).To(gm.BeFalse(), "Result on 201 should not be async")
 	})
 


### PR DESCRIPTION
Following the spec, a message is not required for a 201 credential
provision response. I've updated the client and added a test to match
this behaviour.