### PR TITLE
Use vendored swagger to generate provider client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ $(LINTERS): %: vendor/bin/gometalinter %-bin vendor generated
 #################################################
 
 generated/provider/client generated/provider/models: provider.yaml vendor/bin/swagger
-	swagger generate client -f $< -A provider -t generated/provider
+	vendor/bin/swagger generate client -f $< -A provider -t generated/provider
 	touch generated/provider/client
 	touch generated/provider/models
 

--- a/generated/provider/client/single_sign_on/single_sign_on_client.go
+++ b/generated/provider/client/single_sign_on/single_sign_on_client.go
@@ -44,6 +44,11 @@ the duration of their session.
 The access token is sensitive data that grants access to a user's
 data within Manifold. It should be treated with care.
 
+**IMPORTANT**: A malicious user *could* tamper with the `resource_id`
+query parameter. To prevent this, the provider *must* validate that the
+user has access to the targeted resource by requesting information
+about it from the Connector API using the granted access token.
+
 */
 func (a *Client) GetSso(params *GetSsoParams) (*GetSsoOK, error) {
 	// TODO: Validate the params before sending


### PR DESCRIPTION
Up to this point, Grafton has been relying on the globally installed
swagger client instead of the one we've vendored.

I've fixed this bug, so we should have deterministic client generation
across based on our `glide.lock` file.