### PR TITLE
Grafton Connector Support for JSON POST to create OAuth Token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The Grafton mock connector API now supports a JSON message body to POST /oauth/tokens, as described in the provider documentation
+
 ## [0.12.0] - 2017-11-23
 
 ### Added

--- a/connector/connector_test.go
+++ b/connector/connector_test.go
@@ -11,11 +11,24 @@ import (
 )
 
 var (
-	port         uint
-	clientID     = "21jtaatqj8y5t0kctb2ejr6jev5w8"
-	clientSecret = "3yTKSiJ6f5V5Bq-kWF0hmdrEUep3m3HKPTcPX7CdBZw"
-	product      = "tester"
+	port              uint
+	clientID          = "21jtaatqj8y5t0kctb2ejr6jev5w8"
+	clientSecret      = "3yTKSiJ6f5V5Bq-kWF0hmdrEUep3m3HKPTcPX7CdBZw"
+	product           = "tester"
+	connectorInstance *FakeConnector
 )
+
+func getConnectorInstance() *FakeConnector {
+	if connectorInstance != nil {
+		return connectorInstance
+	}
+	c, err := New(port, clientID, clientSecret, product)
+	if err != nil {
+		gm.Expect(err).ToNot(gm.HaveOccurred())
+	}
+	connectorInstance = c
+	return connectorInstance
+}
 
 func makeResource(t *testing.T, plan, region string) *Resource {
 	ID, err := manifold.NewID(idtype.Resource)
@@ -37,10 +50,7 @@ func makeResource(t *testing.T, plan, region string) *Resource {
 func TestConnector(t *testing.T) {
 	gm.RegisterTestingT(t)
 
-	c, err := New(port, clientID, clientSecret, product)
-	if err != nil {
-		gm.Expect(err).ToNot(gm.HaveOccurred())
-	}
+	c := getConnectorInstance()
 
 	t.Run("a resource is available if added and not if removed", func(t *testing.T) {
 		gm.RegisterTestingT(t)

--- a/connector/oauth_test.go
+++ b/connector/oauth_test.go
@@ -1,0 +1,53 @@
+package connector
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	gm "github.com/onsi/gomega"
+)
+
+func TestCreateAccessTokenHandler(t *testing.T) {
+	gm.RegisterTestingT(t)
+
+	c := getConnectorInstance()
+	r := &RequestCapturer{
+		Route:    "/oauth/tokens",
+		requests: make([]interface{}, 0),
+	}
+	handler := createAccessTokenHandler(c, r)
+
+	t.Run("create access token [client_credentials] responds properly to json data",
+		func(t *testing.T) {
+			gm.RegisterTestingT(t)
+
+			req := httptest.NewRequest("POST", "/oauth/tokens", strings.NewReader(`{
+				"grant_type": "client_credentials",
+				"client_id": "`+clientID+`",
+				"client_secret": "`+clientSecret+`"
+			}`))
+			req.Header.Add("Content-Type", "text/json")
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			gm.Expect(rec.Code).To(gm.Equal(200))
+		})
+
+	t.Run("create access token [client_credentials] responds properly to url encoded data",
+		func(t *testing.T) {
+			gm.RegisterTestingT(t)
+
+			req := httptest.NewRequest("POST", "/oauth/tokens", strings.NewReader(``))
+			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+			req.PostForm = make(url.Values, 3)
+			req.PostForm.Add("grant_type", "client_credentials")
+			req.PostForm.Add("client_id", clientID)
+			req.PostForm.Add("client_secret", clientSecret)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			gm.Expect(rec.Code).To(gm.Equal(200))
+		})
+}


### PR DESCRIPTION
This adds support for a JSON message body in POSTs to Grafton's Connector OAuth create access token route.
This is important because our provider documentation indicates that sending a JSON body for this operation is the correct way to do things.
https://docs.manifold.co/providers#tag/OAuth%2Fpaths%2F~1oauth~1tokens%2Fpost
I also added a couple tests.

Closes manifoldco/engineering#2086