### PR TITLE
Fix exit code on failure

### DIFF
--- a/acceptance/acceptance.go
+++ b/acceptance/acceptance.go
@@ -108,9 +108,9 @@ func Run(ctx context.Context, runErrorCases bool, exclude []string) bool {
 	fakeConnector.Start()
 	defer fakeConnector.Stop()
 
-	ok := walkGraph(ctx, exclude, false, execute)
+	failed := walkGraph(ctx, exclude, false, execute)
 	printSummary(failures, success)
-	return ok
+	return failed
 }
 
 // Validate checks if the test run has all the required information it needs to run

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -266,8 +266,10 @@ func testCmd(ctx *cli.Context) error {
 	if err := acceptance.Configure(cfg); err != nil {
 		return cli.NewExitError("Error: "+err.Error(), -1)
 	}
-	if ok := acceptance.Run(c, !ctx.Bool("no-error-cases"), excludeFeatures); !ok {
-		os.Exit(1)
+
+	failed := acceptance.Run(c, !ctx.Bool("no-error-cases"), excludeFeatures)
+	if failed {
+		os.Exit(-1)
 	}
 
 	return nil


### PR DESCRIPTION
Exit code were reversed due to a misleading variable name. 
It returns 1 when passing instead of 0, and 0 when is failing.

I'm returning -1 now to keep inline with other errors throughout the application:
```
return cli.NewExitError("Error: "+err.Error(), -1)
```

Closes: https://github.com/manifoldco/grafton/issues/66