### PR TITLE
Serve fixes

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -4,12 +4,15 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/url"
+	"regexp"
 
 	"github.com/urfave/cli"
 
 	"github.com/manifoldco/grafton/connector"
 	"github.com/manifoldco/grafton/marketplace"
 )
+
+var pathRegex = regexp.MustCompile(`^(?:.*\/)?v1\/?$`)
 
 func init() {
 	cmd := cli.Command{
@@ -80,6 +83,15 @@ func serveCmd(ctx *cli.Context) error {
 	if err != nil {
 		return cli.NewExitError("Failed to parse provider API URL '"+providerAPI+
 			"' - "+err.Error(), -1)
+	}
+	if !pathRegex.Match([]byte(pAPI.Path)) {
+		path := pAPI.Path
+		if len(path) > 0 && pAPI.Path[len(path)-1] == '/' {
+			pAPI.Path += "v1/"
+		} else {
+			pAPI.Path += "/v1/"
+		}
+		fmt.Printf("'provider-api' was missing the trailing '/v1/' specifier in the path, using: %s\n", pAPI)
 	}
 
 	if clientID == "" && clientSecret == "" {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/manifoldco/grafton/connector"
 	"github.com/manifoldco/grafton/marketplace"
+	"github.com/manifoldco/grafton/marketplace/primitives"
 )
 
 var pathRegex = regexp.MustCompile(`^(?:.*\/)?v1\/?$`)
@@ -24,6 +25,16 @@ func init() {
 				Name:   "product",
 				Usage:  "The label of the product being provisioned",
 				EnvVar: "PRODUCT",
+			},
+			cli.StringFlag{
+				Name:   "plan",
+				Usage:  "The label of the plan being provisioned",
+				EnvVar: "PLAN",
+			},
+			cli.StringFlag{
+				Name:   "region",
+				Usage:  "The label of the region being provisioned",
+				EnvVar: "REGION",
 			},
 			cli.StringFlag{
 				Name:   "client-id",
@@ -60,6 +71,14 @@ func serveCmd(ctx *cli.Context) error {
 	product := ctx.String("product")
 	if product == "" {
 		return cli.NewExitError("The 'product' flag is required and was not provided", -1)
+	}
+	plan := ctx.String("plan")
+	if plan == "" {
+		return cli.NewExitError("The 'plan' flag is required and was not provided", -1)
+	}
+	region := ctx.String("region")
+	if region == "" {
+		return cli.NewExitError("The 'region' flag is required and was not provided", -1)
 	}
 	clientID := ctx.String("client-id")
 	clientSecret := ctx.String("client-secret")
@@ -132,7 +151,12 @@ func serveCmd(ctx *cli.Context) error {
 	if err != nil {
 		return cli.NewExitError("Error while configuring connector service: "+err.Error(), -1)
 	}
-	fakeMarketplace := marketplace.New(fakeConnector, marketplacePort, pAPI, lkp)
+	fakeMarketplace := marketplace.New(fakeConnector, marketplacePort, pAPI, lkp,
+		&primitives.FakeProductData{
+			Product: product,
+			Plan:    plan,
+			Region:  region,
+		})
 
 	fmt.Printf("Starting Connector server on http://localhost:%d\n", connectorPort)
 	fakeConnector.Start()

--- a/marketplace/marketplace.go
+++ b/marketplace/marketplace.go
@@ -12,6 +12,7 @@ import (
 	"github.com/manifoldco/grafton"
 	"github.com/manifoldco/grafton/connector"
 	"github.com/manifoldco/grafton/db"
+	"github.com/manifoldco/grafton/marketplace/primitives"
 	"github.com/manifoldco/grafton/marketplace/routes"
 )
 
@@ -19,6 +20,7 @@ import (
 //  to allow provider to test a full integration experience without integrating
 type FakeMarketplace struct {
 	Port      uint
+	Product   *primitives.FakeProductData
 	DB        *db.DB
 	Connector *connector.FakeConnector
 	GC        *grafton.Client
@@ -27,10 +29,11 @@ type FakeMarketplace struct {
 
 // New creates a new FakeMarketplace based on the passed parameters
 func New(connector *connector.FakeConnector, port uint, pAPI *url.URL,
-	signer grafton.Signer) *FakeMarketplace {
+	signer grafton.Signer, data *primitives.FakeProductData) *FakeMarketplace {
 
 	fm := &FakeMarketplace{
 		Port:      port,
+		Product:   data,
 		DB:        connector.DB,
 		Connector: connector,
 	}
@@ -79,7 +82,7 @@ func Routes(m *FakeMarketplace) *bone.Mux {
 	mux.GetFunc("/", routes.GetResourcesHandler(m.DB))
 
 	mux.GetFunc("/resources", routes.GetResourcesHandler(m.DB))
-	mux.PostFunc("/resources", routes.PostResourcesHandler(m.DB, m.GC, m.Connector))
+	mux.PostFunc("/resources", routes.PostResourcesHandler(m.DB, m.GC, m.Connector, m.Product))
 	mux.PostFunc("/resources/:id", routes.PutResourcesHandler(m.DB))
 	mux.GetFunc("/resources/:id/delete", routes.DeleteResourcesHandler(m.DB, m.GC, m.Connector))
 	mux.GetFunc("/resources/:id/sso", routes.SSOResourcesHandler(m.DB, m.GC, m.Connector))

--- a/marketplace/primitives/fake_product_data.go
+++ b/marketplace/primitives/fake_product_data.go
@@ -1,0 +1,8 @@
+package primitives
+
+// FakeProductData holds all the data we need to do a fake product provisioning call
+type FakeProductData struct {
+	Product string
+	Plan    string
+	Region  string
+}

--- a/marketplace/routes/resources.go
+++ b/marketplace/routes/resources.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/manifoldco/grafton/connector"
 	"github.com/manifoldco/grafton/db"
+	"github.com/manifoldco/grafton/marketplace/primitives"
 )
 
 func respondResourcePage(d *db.DB, rw http.ResponseWriter, req *http.Request, code int, features string) {
@@ -52,7 +53,7 @@ func GetResourcesHandler(d *db.DB) http.HandlerFunc {
 
 // PostResourcesHandler attempts to provision a new resource
 func PostResourcesHandler(d *db.DB, gc *grafton.Client,
-	fc *connector.FakeConnector) http.HandlerFunc {
+	fc *connector.FakeConnector, data *primitives.FakeProductData) http.HandlerFunc {
 
 	return func(rw http.ResponseWriter, req *http.Request) {
 		id, err := manifold.NewID(idtype.Resource)
@@ -83,13 +84,12 @@ func PostResourcesHandler(d *db.DB, gc *grafton.Client,
 
 		// Store in a provisioning state
 		r := &db.Resource{
-			ID:    id,
-			Name:  manifold.Name(name),
-			Label: manifold.Label(name),
-			// TODO: use real values from config
-			Plan:      "ursa-minor",
-			Product:   "bear",
-			Region:    "all::global",
+			ID:        id,
+			Name:      manifold.Name(name),
+			Label:     manifold.Label(name),
+			Plan:      manifold.Label(data.Plan),
+			Product:   manifold.Label(data.Product),
+			Region:    data.Region,
 			CreatedAt: time.Now(),
 			UpdatedAt: time.Now(),
 			State:     db.ResourceStateProvisioning,


### PR DESCRIPTION
This adds support for setting Product, Plan, and Region on `serve` and uses them in the provision call.
This also fixes an issue where `v1` was not getting appended to the provider API url if omitted.