### PR TITLE
Fix error code when there are no failures

### DIFF
--- a/acceptance/acceptance.go
+++ b/acceptance/acceptance.go
@@ -106,9 +106,9 @@ func Run(ctx context.Context, runErrorCases bool, exclude []string) bool {
 	fakeConnector.Start()
 	defer fakeConnector.Stop()
 
-	failed := walkGraph(ctx, exclude, false, execute)
+	walkGraph(ctx, exclude, false, execute)
 	printSummary(failures, success)
-	return failed
+	return failures > 0
 }
 
 // Validate checks if the test run has all the required information it needs to run

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -273,7 +273,7 @@ func testCmd(ctx *cli.Context) error {
 
 	failed := acceptance.Run(c, !ctx.Bool("no-error-cases"), excludeFeatures)
 	if failed {
-		os.Exit(-1)
+		os.Exit(1)
 	}
 
 	return nil


### PR DESCRIPTION
The `execute` function only returns `false` if one of the tests panics, so the `walkGraph` result variable name as `failed` was misleading. It didn't represent if at least of the tests actually failed.

Now we are checking for the number of failures greater than 0 and return `1` as the error code.

Before Successful tests:

```
22 features, 0 failures
2019/01/04 20:09:05 exit status 255
```

Before Failed tests:

```
23 features, 1 failures
2019/01/04 20:09:35 exit status 255
```

With this PR Successful tests:

```
22 features, 0 failures
```

With this PR Failed tests:

```
23 features, 1 failures
2019/01/04 20:10:37 exit status 1
```