### PR TITLE
Fix the fake connector oauth/tokens route

### DIFF
--- a/connector/oauth_test.go
+++ b/connector/oauth_test.go
@@ -1,12 +1,12 @@
 package connector
 
 import (
+	"encoding/base64"
+	gm "github.com/onsi/gomega"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
-
-	gm "github.com/onsi/gomega"
 )
 
 func TestCreateAccessTokenHandler(t *testing.T) {
@@ -28,7 +28,7 @@ func TestCreateAccessTokenHandler(t *testing.T) {
 				"client_id": "`+clientID+`",
 				"client_secret": "`+clientSecret+`"
 			}`))
-			req.Header.Add("Content-Type", "text/json")
+			req.Header.Add("Content-Type", "application/json")
 			rec := httptest.NewRecorder()
 
 			handler.ServeHTTP(rec, req)
@@ -49,5 +49,130 @@ func TestCreateAccessTokenHandler(t *testing.T) {
 
 			handler.ServeHTTP(rec, req)
 			gm.Expect(rec.Code).To(gm.Equal(201))
+		})
+
+	t.Run("create access token [client_credentials] responds properly to a body and a Authorization header",
+		func(t *testing.T) {
+			gm.RegisterTestingT(t)
+
+			req := httptest.NewRequest("POST", "/oauth/tokens", strings.NewReader(`{
+				"grant_type": "client_credentials"
+			}`))
+			req.Header.Add("Content-Type", "application/json")
+			req.Header.Add("Authorization", "Basic "+base64.URLEncoding.EncodeToString([]byte(clientID+":"+clientSecret)))
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			gm.Expect(rec.Code).To(gm.Equal(201))
+		})
+
+	t.Run("create access token [authorization_code] responds properly to json data",
+		func(t *testing.T) {
+			gm.RegisterTestingT(t)
+
+			authCode, err := c.CreateCode()
+			gm.Expect(err).ToNot(gm.HaveOccurred())
+
+			req := httptest.NewRequest("POST", "/oauth/tokens", strings.NewReader(`{
+				"grant_type": "authorization_code",
+				"client_id": "`+clientID+`",
+				"client_secret": "`+clientSecret+`",
+				"code": "`+authCode.Code+`"
+			}`))
+			req.Header.Add("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			gm.Expect(rec.Code).To(gm.Equal(201))
+		})
+
+	t.Run("create access token [authorization_code] responds properly to url encoded data",
+		func(t *testing.T) {
+			gm.RegisterTestingT(t)
+
+			authCode, err := c.CreateCode()
+			gm.Expect(err).ToNot(gm.HaveOccurred())
+
+			req := httptest.NewRequest("POST", "/oauth/tokens", strings.NewReader(``))
+			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+			req.PostForm = make(url.Values, 3)
+			req.PostForm.Add("grant_type", "authorization_code")
+			req.PostForm.Add("client_id", clientID)
+			req.PostForm.Add("client_secret", clientSecret)
+			req.PostForm.Add("code", authCode.Code)
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			gm.Expect(rec.Code).To(gm.Equal(201))
+		})
+
+	t.Run("create access token [authorization_code] responds properly to json data and an Authorization header",
+		func(t *testing.T) {
+			gm.RegisterTestingT(t)
+
+			authCode, err := c.CreateCode()
+			gm.Expect(err).ToNot(gm.HaveOccurred())
+
+			req := httptest.NewRequest("POST", "/oauth/tokens", strings.NewReader(`{
+				"grant_type": "authorization_code",
+				"code": "`+authCode.Code+`"
+			}`))
+			req.Header.Add("Content-Type", "application/json")
+			req.Header.Add("Authorization", "Basic "+base64.URLEncoding.EncodeToString([]byte(clientID+":"+clientSecret)))
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			gm.Expect(rec.Code).To(gm.Equal(201))
+		})
+
+	t.Run("create access token will return an error for an empty or invalid request body",
+		func(t *testing.T) {
+			gm.RegisterTestingT(t)
+
+			req := httptest.NewRequest("POST", "/oauth/tokens", strings.NewReader(""))
+			req.Header.Add("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			gm.Expect(rec.Code).To(gm.Equal(400))
+
+			req = httptest.NewRequest("POST", "/oauth/tokens", strings.NewReader("{"))
+			req.Header.Add("Content-Type", "application/json")
+			rec = httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			gm.Expect(rec.Code).To(gm.Equal(400))
+		})
+
+	t.Run("create access token will return an error for an invalid grant_type",
+		func(t *testing.T) {
+			gm.RegisterTestingT(t)
+
+			req := httptest.NewRequest("POST", "/oauth/tokens", strings.NewReader(`{
+				"grant_type": "random",
+				"client_id": "`+clientID+`",
+				"client_secret": "`+clientSecret+`"
+			}`))
+			req.Header.Add("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			gm.Expect(rec.Code).To(gm.Equal(400))
+		})
+
+	t.Run("create access token [authorization_code] will return an error if the code is missing",
+		func(t *testing.T) {
+			gm.RegisterTestingT(t)
+
+			req := httptest.NewRequest("POST", "/oauth/tokens", strings.NewReader(`{
+				"grant_type": "authorization_code",
+				"client_id": "`+clientID+`",
+				"client_secret": "`+clientSecret+`"
+			}`))
+			req.Header.Add("Content-Type", "application/json")
+			rec := httptest.NewRecorder()
+
+			handler.ServeHTTP(rec, req)
+			gm.Expect(rec.Code).To(gm.Equal(400))
 		})
 }


### PR DESCRIPTION
The route expected the autorization code to be in a `application/x-www-form-urlencoded` content-type. It also had some issue with the order of things which could empty the client_id and client_secret if you provided both a body and an Authorization header.