### PR TITLE
Add manual rotation tests

### DIFF
--- a/acceptance/acceptance.go
+++ b/acceptance/acceptance.go
@@ -27,6 +27,8 @@ var region string
 var newPlan string
 var newPlanFeatures manifold.FeatureMap
 var resourceMeasures map[string]int64
+var credentialType string
+var credentialRotationType string
 
 var clientID string
 var clientSecret string
@@ -66,6 +68,8 @@ func Configure(cfg Configuration) error {
 	planFeatures = cfg.PlanFeatures
 	newPlan = cfg.NewPlan
 	newPlanFeatures = cfg.NewPlanFeatures
+	credentialType = "single"
+	credentialRotationType = "none"
 
 	clientID = cfg.ClientID
 	clientSecret = cfg.ClientSecret

--- a/acceptance/rotation.go
+++ b/acceptance/rotation.go
@@ -48,13 +48,16 @@ var rotateCreds = Feature("credentials-rotation", "Credential rotation", func(ct
 	}
 })
 
-var _ = rotateCreds.TearDown("credentials-rotation", func(ctx context.Context) {
+var _ = rotateCreds.TearDown("Remove created Credentials", func(ctx context.Context) {
+	if rotationTearDown == nil {
+		return
+	}
 	rotationTearDown(ctx)
 })
 
 func featureRotateCredsSingleManual(ctx context.Context) {
 	var rotatedCredentialID manifold.ID
-	Default(func() {
+	block("Default case: manual rotation with single credentials", func() {
 		initialCredID, initialValues := mustProvisionCredentials(ctx, api, resourceID)
 
 		// delete initial credential before creating new one
@@ -78,7 +81,7 @@ func featureRotateCredsSingleManual(ctx context.Context) {
 
 func featureRotateCredsMultipleManual(ctx context.Context) {
 	var rotatedCredentialID manifold.ID
-	Default(func() {
+	block("Default case: manual rotation with multiple credentials", func() {
 		initialCredID, initialValues := mustProvisionCredentials(ctx, api, resourceID)
 		rID, rotatedValues := mustProvisionCredentials(ctx, api, resourceID)
 		rotatedCredentialID = rID

--- a/acceptance/rotation.go
+++ b/acceptance/rotation.go
@@ -1,0 +1,126 @@
+package acceptance
+
+import (
+	"context"
+	"time"
+
+	"github.com/manifoldco/go-manifold"
+	merrors "github.com/manifoldco/go-manifold/errors"
+	"github.com/manifoldco/go-manifold/idtype"
+	gm "github.com/onsi/gomega"
+
+	"github.com/manifoldco/grafton"
+	"github.com/manifoldco/grafton/connector"
+)
+
+var rotatedCredentialID manifold.ID
+
+var rotateCreds = Feature("credentials_rotation", "Credential rotation", func(ctx context.Context) {
+	// TODO: Change this to a bunch of ifs using the rotation type flag
+	rotateCredsMultipleManual(ctx)
+})
+
+func rotateCredsMultipleManual(ctx context.Context) {
+	Default(func() {
+		ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		defer cancel()
+
+		cID, creds, callbackID, async, err := provisionCredentials(ctx, api, resourceID)
+		gm.Expect(err).To(notError(), "Expected a successful provision of a new set of Credentials")
+
+		if async {
+			c := fakeConnector.GetCallback(callbackID)
+			gm.Expect(c.State).To(
+				gm.Equal(connector.DoneCallbackState),
+				"Expected to receive 'done' as the state",
+			)
+			gm.Expect(len(c.Message)).To(gm.SatisfyAll(
+				gm.BeNumerically(">=", 3),
+				gm.BeNumerically("<", 256),
+			), "Message must be between 3 and 256 characters long.")
+			gm.Expect(len(c.Credentials)).To(
+				gm.BeNumerically(">", 0),
+				"One or more credential should be returned during provision of a new Credential set",
+			)
+		}
+
+		gm.Expect(len(creds)).To(
+			gm.BeNumerically(">", 0),
+			"One or more credentials should be returned during provision of a new Credential set",
+		)
+
+		for name := range creds {
+			gm.Expect(grafton.ValidCredentialName(name)).To(
+				gm.BeTrue(), "Credential name must be of the form "+grafton.NameRegexpString)
+		}
+
+		rotatedCredentialID = cID
+	})
+
+	ErrorCase("with an invalid resource ID", func() {
+		ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		defer cancel()
+		var err error
+
+		fakeResourceID, _ := manifold.NewID(idtype.Resource)
+		_, _, _, async, err := provisionCredentials(ctx, api, fakeResourceID)
+
+		gm.Expect(async).To(
+			gm.BeFalse(),
+			"Validation errors should be returned on the initial request",
+		)
+		gm.Expect(err).ShouldNot(
+			gm.BeNil(),
+			"Expected an error, got nil",
+		)
+		gm.Expect(err).Should(
+			gm.BeAssignableToTypeOf(&grafton.Error{}),
+			"Expected a grafton error, got %T", err,
+		)
+
+		e := err.(*grafton.Error)
+		gm.Expect(e.Type).Should(gm.Equal(merrors.NotFoundError))
+	})
+
+	ErrorCase("with already provisioned credentials - same content acts as created", func() {
+		ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		defer cancel()
+		var err error
+
+		_, _, _, async, err := provisionCredentialsID(ctx, api, rotatedCredentialID, resourceID)
+
+		gm.Expect(async).To(
+			gm.BeFalse(),
+			"Same content should be evaluated during the initial call from Manifold",
+		)
+		gm.Expect(err).To(
+			notError(),
+			"Create response should be returned (Repeatable Action)",
+		)
+	})
+
+	ErrorCase("with a bad signature", func() {
+		ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		defer cancel()
+
+		_, _, _, async, err := provisionCredentials(ctx, uapi, resourceID)
+
+		gm.Expect(async).To(
+			gm.BeFalse(),
+			"Validation errors should be returned on the initial request",
+		)
+		gm.Expect(err).ShouldNot(
+			gm.BeNil(),
+			"Expected an error, got nil",
+		)
+		gm.Expect(err).Should(
+			gm.BeAssignableToTypeOf(&grafton.Error{}),
+			"Expected a grafton error, got %T", err,
+		)
+
+		e := err.(*grafton.Error)
+		gm.Expect(e.Type).Should(gm.Equal(merrors.UnauthorizedError))
+	})
+}
+
+var _ = rotateCreds.RunsInside("provision")


### PR DESCRIPTION
Backend for testing manual credential rotation. This will be disabled for now until we add new command line flags.

For https://github.com/manifoldco/engineering/issues/7645 & https://github.com/manifoldco/engineering/issues/7616

<img width="666" alt="Screen Shot 2019-04-08 at 12 37 58 PM" src="https://user-images.githubusercontent.com/6145422/55741429-3a392e00-59fb-11e9-9743-a4f3e6b4e643.png">
<img width="662" alt="Screen Shot 2019-04-08 at 12 38 22 PM" src="https://user-images.githubusercontent.com/6145422/55741430-3a392e00-59fb-11e9-9b60-dfcd6e472c40.png">
