### PR TITLE
Add credential flag to grafton

### DIFF
--- a/acceptance/acceptance.go
+++ b/acceptance/acceptance.go
@@ -53,6 +53,7 @@ type Configuration struct {
 	Port             uint
 	CallbackTimeout  string
 	ResourceMeasures string
+	Credential       string
 }
 
 // Configure configures all the values needed to run the acceptance tests.
@@ -67,7 +68,7 @@ func Configure(cfg Configuration) error {
 	planFeatures = cfg.PlanFeatures
 	newPlan = cfg.NewPlan
 	newPlanFeatures = cfg.NewPlanFeatures
-	credentialType = "unknown"
+	credentialType = cfg.Credential
 
 	clientID = cfg.ClientID
 	clientSecret = cfg.ClientSecret

--- a/acceptance/credentials.go
+++ b/acceptance/credentials.go
@@ -26,20 +26,6 @@ var creds = Feature("credentials", "Create a credential set", func(ctx context.C
 		credentialID = cID
 	})
 
-	if credentialType == "multiple" {
-		Case("Case: Multiple credential sets", func() {
-			cID1, val1 := mustProvisionCredentials(ctx, api, resourceID)
-			cID2, val2 := mustProvisionCredentials(ctx, api, resourceID)
-
-			// assert credentials have different values
-			gm.Expect(val1).ToNot(
-				gm.Equal(val2), "Different credentials expected for new Credential Set")
-
-			mustDeprovisionCredentials(ctx, api, cID1)
-			mustDeprovisionCredentials(ctx, api, cID2)
-		})
-	}
-
 	ErrorCase("with an invalid resource ID", func() {
 		ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
 		defer cancel()

--- a/acceptance/rotation.go
+++ b/acceptance/rotation.go
@@ -16,9 +16,6 @@ var rotateCreds = Feature("credentials-rotation", "Rotate a credential set", fun
 		featureReplaceRotation(ctx)
 	case "multiple":
 		featureSwapRotation(ctx)
-	case "unknown":
-		// No rotation
-		Default(func() {})
 	default:
 		Default(func() {
 			FatalErr("unknown credentialType %s", credentialType)
@@ -37,7 +34,7 @@ var _ = rotateCreds.RunsInside("provision")
 
 func featureReplaceRotation(ctx context.Context) {
 	var rotatedCredentialID manifold.ID
-	Default(func() {
+	Case("single credential replace", func() {
 		initialCredID, initialValues := mustProvisionCredentials(ctx, api, resourceID)
 
 		// delete initial credential before creating new one
@@ -61,7 +58,7 @@ func featureReplaceRotation(ctx context.Context) {
 
 func featureSwapRotation(ctx context.Context) {
 	var rotatedCredentialID manifold.ID
-	Default(func() {
+	Case("multiple credentials swap", func() {
 		initialCredID, initialValues := mustProvisionCredentials(ctx, api, resourceID)
 		rID, rotatedValues := mustProvisionCredentials(ctx, api, resourceID)
 		rotatedCredentialID = rID

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -108,6 +108,11 @@ func init() {
 				Usage: "Optional measures map to be returned by resource measures",
 				Value: `{"feature-a": 0, "feature-b": 1000}`,
 			},
+			cli.StringFlag{
+				Name:  "credential",
+				Usage: "Describes the credential type that is supported by this product. One of (single, multiple)",
+				Value: "multiple",
+			},
 		},
 		Action: testCmd,
 	}
@@ -133,6 +138,8 @@ func testCmd(ctx *cli.Context) error {
 	callbackTimeout := ctx.String("callback-timeout")
 
 	resourceMeasures := ctx.String("resource-measures")
+
+	credential := ctx.String("credential")
 
 	var logLevel acceptance.LogLevel
 	rawLevel := ctx.String("log")
@@ -265,6 +272,7 @@ func testCmd(ctx *cli.Context) error {
 		Port:             connectorPort,
 		CallbackTimeout:  callbackTimeout,
 		ResourceMeasures: resourceMeasures,
+		Credential:       credential,
 	}
 
 	if err := acceptance.Configure(cfg); err != nil {


### PR DESCRIPTION
Add `credential` flag to grafton. It defaults to `multiple`.