### PR TITLE
feat: allow pointing grafton to different api hostnames

### DIFF
--- a/cmd/credentials.go
+++ b/cmd/credentials.go
@@ -23,7 +23,20 @@ import (
 )
 
 const passwordMask = '●'
-const apiURL = "https://api.%s.manifold.co/v1"
+const defaultHostname = "manifold.co"
+const defaultScheme = "https"
+
+func apiURLPattern() string {
+	scheme := os.Getenv("MANIFOLD_SCHEME")
+	if scheme == "" {
+		scheme = defaultScheme
+	}
+	hostname := os.Getenv("MANIFOLD_HOSTNAME")
+	if hostname == "" {
+		hostname = defaultHostname
+	}
+	return fmt.Sprintf("%s://api.%s.%s/v1", scheme, "%s", hostname)
+}
 
 var credentialFlags = []cli.Flag{
 	cli.StringFlag{
@@ -193,7 +206,7 @@ func deleteCredentialsCmd(cliCtx *cli.Context) error {
 
 // NewConnector creates a new connector client with the provided 'token'
 func NewConnector(token string) (*client.Connector, error) {
-	u, err := url.Parse(fmt.Sprintf(apiURL, "connector"))
+	u, err := url.Parse(fmt.Sprintf(apiURLPattern(), "connector"))
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +262,7 @@ func login(ctx context.Context) (*manifold.Client, string, error) {
 	}
 	cfgs := []manifold.ConfigFunc{}
 
-	cfgs = append(cfgs, manifold.ForURLPattern(apiURL))
+	cfgs = append(cfgs, manifold.ForURLPattern(apiURLPattern()))
 	cfgs = append(cfgs, manifold.WithUserAgent("grafton-"+config.Version))
 
 	client := manifold.New(cfgs...)

--- a/cmd/credentials_test.go
+++ b/cmd/credentials_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	gm "github.com/onsi/gomega"
+)
+
+func Test_apiURLPattern(t *testing.T) {
+	gm.RegisterTestingT(t)
+	oldManifoldHostname := os.Getenv("MANIFOLD_HOSTNAME")
+	defer func() {
+		os.Setenv("MANIFOLD_HOSTNAME", oldManifoldHostname)
+	}()
+	oldManifoldScheme := os.Getenv("MANIFOLD_SCHEME")
+	defer func() {
+		os.Setenv("MANIFOLD_SCHEME", oldManifoldScheme)
+	}()
+
+	gm.Expect(apiURLPattern()).To(gm.Equal("https://api.%s.manifold.co/v1"))
+
+	os.Setenv("MANIFOLD_HOSTNAME", "my-hostname")
+	os.Setenv("MANIFOLD_SCHEME", "my-scheme")
+	gm.Expect(apiURLPattern()).To(gm.Equal("my-scheme://api.%s.my-hostname/v1"))
+}


### PR DESCRIPTION
Using `MANIFOLD_HOSTNAME` and `MANIFOLD_SCHEME` one can point grafton's credentials commands to different API endpoints.