### PR TITLE
Add more logs to grafton when sending requests to a provider API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Add more details on error cases where a different status code was received.
+- Add more helpful logs when using grafton to send request to an API with logging enabled.
 
 ## [0.15.3] - 2019-08-15
 

--- a/client_test.go
+++ b/client_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	gm "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 
 	"github.com/manifoldco/go-manifold"
 	"github.com/manifoldco/go-manifold/errors"
@@ -22,7 +23,7 @@ func (stubSigner) Sign([]byte) (*signature.Signature, error) { return &signature
 func callProvision(rawURL string) (string, bool, error) {
 	ctx := context.Background()
 	sURL, _ := url.Parse(rawURL)
-	c := New(sURL, &url.URL{}, stubSigner{}, nil)
+	c := New(sURL, &url.URL{}, stubSigner{}, logrus.NewEntry(logrus.New()))
 
 	cbID := manifold.ID{}
 	resID := manifold.ID{}
@@ -46,7 +47,7 @@ func callProvision(rawURL string) (string, bool, error) {
 func callProvisionCredentials(rawURL string) (map[string]string, string, bool, error) {
 	ctx := context.Background()
 	sURL, _ := url.Parse(rawURL)
-	c := New(sURL, &url.URL{}, stubSigner{}, nil)
+	c := New(sURL, &url.URL{}, stubSigner{}, logrus.NewEntry(logrus.New()))
 
 	cbID := manifold.ID{}
 	resID := manifold.ID{}
@@ -57,7 +58,7 @@ func callProvisionCredentials(rawURL string) (map[string]string, string, bool, e
 func callChangePlan(rawURL string) (string, bool, error) {
 	ctx := context.Background()
 	sURL, _ := url.Parse(rawURL)
-	c := New(sURL, &url.URL{}, stubSigner{}, nil)
+	c := New(sURL, &url.URL{}, stubSigner{}, logrus.NewEntry(logrus.New()))
 
 	cbID := manifold.ID{}
 	resID := manifold.ID{}
@@ -73,7 +74,7 @@ func callDeprovisionCredentials(rawURL string) (string, bool, error) {
 	ctx := context.Background()
 	sURL, _ := url.Parse(rawURL)
 
-	c := New(sURL, &url.URL{}, stubSigner{}, nil)
+	c := New(sURL, &url.URL{}, stubSigner{}, logrus.NewEntry(logrus.New()))
 
 	cbID := manifold.ID{}
 	credID := manifold.ID{}
@@ -85,7 +86,7 @@ func callDeprovisionResource(rawURL string) (string, bool, error) {
 	ctx := context.Background()
 	sURL, _ := url.Parse(rawURL)
 
-	c := New(sURL, &url.URL{}, stubSigner{}, nil)
+	c := New(sURL, &url.URL{}, stubSigner{}, logrus.NewEntry(logrus.New()))
 
 	cbID := manifold.ID{}
 	resID := manifold.ID{}

--- a/go.mod
+++ b/go.mod
@@ -33,18 +33,16 @@ require (
 	github.com/manifoldco/go-manifold v0.13.2
 	github.com/manifoldco/go-signature v1.0.2
 	github.com/manifoldco/promptui v0.3.3-0.20190411181407-35bab80e16a4
-	github.com/onsi/ginkgo v1.7.0 // indirect
 	github.com/onsi/gomega v1.7.1
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.4.2
-	github.com/spf13/viper v1.2.1 // indirect
 	github.com/toqueteos/webbrowser v1.1.0 // indirect
 	github.com/tsenart/deadcode v0.0.0-20160724212837-210d2dc333e9
 	github.com/tylerb/graceful v1.2.15 // indirect
 	github.com/urfave/cli v1.22.1
-	golang.org/x/crypto v0.0.0-20190411141940-e7b772b7007a
-	golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1
-	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
+	golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392
+	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3
+	golang.org/x/net v0.0.0-20190923162816-aa69164e4478
 )
 
 replace sourcegraph.com/sourcegraph/go-diff v0.5.1 => github.com/sourcegraph/go-diff v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -414,6 +414,7 @@ golang.org/x/crypto v0.0.0-20190313024323-a1f597ede03a/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190411141940-e7b772b7007a h1:mNGp7ZBW4qGKTPgfg91TAiPHc+ar+/jWosDTHwCQglk=
 golang.org/x/crypto v0.0.0-20190411141940-e7b772b7007a/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392 h1:ACG4HJsFiNMf47Y4PeRoebLNy/2lXT9EtprMuTFWt1M=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3 h1:x/bBzNauLQAlE3fLku/xy92Y8QwKX5HZymrMz2IiKFc=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -462,6 +463,7 @@ golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190922100055-0a153f010e69 h1:rOhMmluY6kLMhdnrivzec6lLgaVbMHMn2ISQXJeJ5EM=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915090833-1cbadb444a80/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=


### PR DESCRIPTION
These logs will display some of the basic information we and providers need to be able to debug an integration when live. These logs will make sure to no send sensitive information and only give us the required information to support an integration.

Work is related to manifoldco/engineering#10115