### PR TITLE
Use ./ to run manifold and promulgate since they're local

### DIFF
--- a/scripts/release.go
+++ b/scripts/release.go
@@ -22,6 +22,6 @@ func ReleaseZips() error {
 		return err
 	}
 
-	command := fmt.Sprintf("manifold run -t manifold -p promulgate -- promulgate release v%s", tag)
+	command := fmt.Sprintf("./manifold run -t manifold -p promulgate -- ./promulgate release v%s", tag)
 	return cast.Sh(command)
 }


### PR DESCRIPTION
Manifold and promulgate are downloaded locally and are not available in the `$PATH` variable, thus we need to use `./` to call them.