### PR TITLE
Expose the manifold token so we can release using the CLI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,3 +47,4 @@ jobs:
         env:
           MANIFOLD_VERSION: 0.15.1
           PROMULGATE_VERSION: 0.0.9
+          MANIFOLD_API_TOKEN: ${{ secrets.MANIFOLD_API_TOKEN }}


### PR DESCRIPTION
Github actions do not expose env vars by default.