### PR TITLE
Remove prefixed v from the version number

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,3 +47,4 @@ jobs:
         env:
           MANIFOLD_VERSION: 0.15.1
           PROMULGATE_VERSION: 0.0.9
+          MANIFOLD_API_TOKEN: ${{ secrets.MANIFOLD_API_TOKEN }}

--- a/scripts/build.go
+++ b/scripts/build.go
@@ -27,7 +27,7 @@ func Version() (string, error) {
 
 	parts := strings.Split(desc, "-")
 
-	version = parts[0]
+	version = strings.Replace(parts[0], "v", "", 1)
 	return version, nil
 }
 


### PR DESCRIPTION
We used to remove it with sed, it was omitted when initially converting to mage.