### PR TITLE
Change the release condition to run on tag push

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,7 +37,7 @@ jobs:
           token: ${{secrets.CODECOV_TOKEN}} #required
 
       - name: Release
-        if: github.ref == 'refs/heads/master' # only run on master branch
+        if: startsWith(github.ref, 'refs/tags') # only run on tag creation
         run: |
           curl -LO "https://releases.manifold.co/manifold-cli/${MANIFOLD_VERSION}/manifold-cli_${MANIFOLD_VERSION}_linux_amd64.tar.gz"
           tar xvf manifold-cli_*


### PR DESCRIPTION
It was running on master before hand, now it should only run when a tag is pushed. It will then create the release as excepted.